### PR TITLE
connectcore: fix an issue with datapoints monitor receiving bad JSON

### DIFF
--- a/connectcore/connectcorecore/drm_requests.py
+++ b/connectcore/connectcorecore/drm_requests.py
@@ -264,9 +264,9 @@ STATUS_CANCELED = "canceled"
 STATUS_FAILED = "failed"
 
 STREAMS_LIST = ["wlan0/state", "wlan0/rx_bytes", "wlan0/tx_bytes", "hci0/state", "hci0/rx_bytes", "hci0/tx_bytes",
-                "eth0/state", "eth0/rx_bytes", "eth0/tx_bytes", "lo/state", "lo/rx_bytes", "lo/tx_bytes", "uptime",
-                "frequency", "cpu_temperature", "cpu_load", "used_memory", "free_memory", "eth1/state",
-                "eth1/rx_bytes", "eth1/tx_bytes"]
+                "eth0/state", "eth0/rx_bytes", "eth0/tx_bytes", "eth1/state", "eth1/rx_bytes", "eth1/tx_bytes",
+                "lo/state", "lo/rx_bytes", "lo/tx_bytes", "uptime", "frequency", "cpu_temperature", "cpu_load",
+                "used_memory", "free_memory"]
 
 TARGET_DEVICE_INFO = "device_info"
 TARGET_PLAY_MUSIC = "play_music"


### PR DESCRIPTION
The filter added to receive only certain datapoints in the datapoints monitor had the 'eth1' streams in the last position of the list. For devices without 'eth1' interface, this was causing the received JSON string to have a trailing colon, which ended in a JSON parsing error.

Signed-off-by: David Escalona <david.escalona@digi.com>