### PR TITLE
requirements: update cryptography and pyOpenSSL to the latest ones

### DIFF
--- a/connectcore/requirements.txt
+++ b/connectcore/requirements.txt
@@ -13,7 +13,7 @@ channels-redis==3.4.0; sys_platform=='linux'
 chardet==4.0.0
 charset-normalizer==2.0.12
 constantly==15.1.0
-cryptography==37.0.2
+cryptography==39.0.0
 daphne==3.0.2
 devicecloud==0.5.9
 Django==4.0.4
@@ -25,7 +25,7 @@ msgpack==1.0.3
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
-pyOpenSSL==22.0.0
+pyOpenSSL==23.0.0
 python-dateutil==2.8.2
 requests==2.27.1
 service-identity==21.1.0


### PR DESCRIPTION
Without this update the following error is thrown when a new virtual environment is created:
```
   $ python3 run_web_app.py
    +-------------------------------+
    | Digi ConnectCore demo WEB app |
    +-------------------------------+

    Please, wait while the script prepares the virtual environment
    and runs the WEB server...

   - Checking project structure... [OK]
   - Generating virtual environment... Reading package lists... Done Building dependency tree Reading state information... Done python3.8-venv is already the newest version (3.8.10-0ubuntu1~20.04.6). 0 upgraded, 0 newly installed, 0 to remove and 85 not upgraded. [OK]
   - Installing basic modules... [OK]
   - Installing application requirements:
     - Installing module 'aioredis==1.3.1; sys_platform=='linux''... [OK]
     - Installing module 'arrow==1.2.2'... [OK] [...]
   - Initializing Django database... Traceback (most recent call last): File "run_web_app.py", line 338, in <module> main() File "run_web_app.py", line 320, in main if run_venv_python(venv_context, [manage_file, "makemigrations"], File "run_web_app.py", line 127, in run_venv_python return subprocess.check_call(command, File "/usr/lib/python3.8/subprocess.py", line 364, in check_call raise CalledProcessError(retcode, cmd) subprocess.CalledProcessError: Command '['/[...]/digi-iot-web-apps/connectcore/.venv/bin/python3', '/[...]/digi-iot-web-apps/connectcore/./manage.py', 'makemigrations']' returned non-zero exit status 1.

   $ python3 run_web_app.py
    +-------------------------------+
    | Digi ConnectCore demo WEB app |
    +-------------------------------+

    Please, wait while the script prepares the virtual environment
    and runs the WEB server...

   - Checking project structure... [OK]
   - Running WEB server...

      > Watching for file changes with StatReloader
      > Exception in thread django-main-thread:
      > Traceback (most recent call last):
      >   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
      >     self.run()
      >   File "/usr/lib/python3.8/threading.py", line 870, in run
      >     self._target(*self._args, **self._kwargs)
      [...]
      >   File "/[...]/digi-iot-web-apps/connectcore/.venv/lib/python3.8/site-packages/OpenSSL/crypto.py", line 3268, in <module>
      >     _lib.OpenSSL_add_all_algorithms()
      > AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'
```
See Confluence question
https://onedigi.atlassian.net/wiki/display/DEY/customcontent/234736123922