### PR TITLE
connectcore: improve monitors and web-sockets stability

### DIFF
--- a/connectcore/login/views.py
+++ b/connectcore/login/views.py
@@ -79,7 +79,7 @@ def redirect_dest(request):
     url = ROOT_DIR
     if PARAM_DEST in request.GET:
         url += "{}/?".format((request.GET[PARAM_DEST].replace(ROOT_DIR, "")
-                             if ROOT_DIR is not "/" else request.GET[PARAM_DEST]).replace("/", ""))
+                             if ROOT_DIR != "/" else request.GET[PARAM_DEST]).replace("/", ""))
         args = ""
         for arg in request.GET:
             if arg != PARAM_DEST:

--- a/connectcore/static_files/js/sidebar.js
+++ b/connectcore/static_files/js/sidebar.js
@@ -223,6 +223,10 @@ function subscribeDeviceMonitor() {
     deviceSocket.onmessage = function(e) {
         // Retrieve new status.
         var event = JSON.parse(e.data);
+        if (event[ID_ERROR] != null) {
+            toastr.error(event[ID_ERROR]);
+            return;
+        }
         if (event[ID_STATUS] != null && event[ID_STATUS] != "undefined") {
             if (event[ID_STATUS] == "connected")
                 deviceConnectionStatus = true;
@@ -230,6 +234,17 @@ function subscribeDeviceMonitor() {
                 deviceConnectionStatus = false;
             // Fire connection status changed event.
             connection_status_changed();
+        }
+    };
+    // Once socket connection is established, subscribe monitor.
+    deviceSocket.onopen = function(e) {
+        deviceSocket.send("Subscribe monitor");
+    }
+    // If socket is closed unexpectedly, reconnect.
+    deviceSocket.onclose = function(event) {
+        if (!event.wasClean) {
+            deviceSocket = null;
+            subscribeDeviceMonitor();
         }
     };
 }


### PR DESCRIPTION
- Reconnect web-sockets in the case an unclean disconnect is detected.
- Register monitors after web socket connection is established to avoid long duration task in the connect callback.
- Remove all non-active monitors everytime a new monitor is registered.
- Append a dummy datapoint at the end of the monitor schema to avoid invalid JSON strings to be generated with a trailing comma.