### PR TITLE
connectcore: remove link to create DRM account in the login page

### DIFF
--- a/connectcore/login/templates/login.html
+++ b/connectcore/login/templates/login.html
@@ -12,7 +12,6 @@ Digi Demo - Login
             {{ form.as_table }}
             <button type="submit" class="login-button">Login</button>
         </form>
-        <span class="create-account">Don't have a DRM account? <a href="https://myaccount.digi.com/" target="_blank">Create one</a></span>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
The link points to an old portal used to create Digi Remote Manager accounts which is no longer available.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>